### PR TITLE
Fix Babel loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ const babelConfig = {
   configFile: false,
   presets: [
     [
-      "@babel/preset-env",
+      require("@babel/preset-env"),
       {
         targets: {
           chrome: "87", // latest beta release as of this commit (V8 8.6)


### PR DESCRIPTION
This plugin is a core plugin, i.e. it is a `dependencies` of `@netlify/build`. `@netlify/build` is installed in the buildbot as a global `npm` binary. So this plugin runs at `/opt/buildhome/.nvm/versions/v12.16.3/lib/node_modules/@netlify/plugin-edge-handlers/src/index.js` in production.

However the build directory is (usually) at `/opt/build/repo`. Build plugins current directory is set to be the same as the build directory: since all plugins manipulate Site files, plugin expect this behavior (including core plugins). They do not care about where Netlify Build is installed. Instead, they care about where the user Site is.

In other terms, the build/site directory is different from the directory in which Netlify Build (and therefore this plugin) runs. 

This plugin uses Babel through the [official Rollup plugin](https://github.com/rollup/plugins/tree/master/packages/babel). Babel needs to know the current directory for many reasons. One is to load Node modules that are specified as strings such as [`@babel/preset-env`](https://github.com/netlify/netlify-plugin-edge-handlers/blob/d5a9cad05da319bdedde90ce516c82f06bf5d3d0/src/index.js#L68). Other include the `exclude` option, and more.  This is configured using a `cwd` option:

https://github.com/babel/babel/blob/bbe0cf09fc60c130fc63a7176e563781582612b8/packages/babel-core/src/config/partial.js#L81

This option defaults to the current directory (in our case: the build directory). This is a good thing since we want Babel logic to be relative to the Site's directory, so I don't think we should configure that option. However, this creates an issue when requiring `@babel/preset-env` since this is available as a Netlify build dependency. In an usual environment, the directory being transpiled and the directory performing the transpiling would be the same, but not in our case. 

This PR solves this problem by directly requiring `@babel/preset-env` instead of relying on Babel requiring it. Since `require()` depends on `__dirname`, this resolves correctly. I have tried it in production, and this should fix the problem.
