### PR TITLE
Fail when api token is missing

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -16,6 +16,10 @@ const { API_HOST, CONTENT_TYPE } = require("./consts");
  * @returns {Promise<boolean>} Whether the bundle was newly uploaded (and did not already exist)
  */
 async function uploadBundle(buf, info, deployId, apiToken) {
+  if (!apiToken) {
+    throw new Error("API token is missing");
+  }
+
   const resp = await fetch(`https://${API_HOST}/api/v1/deploys/${deployId}/edge_handlers`, {
     method: "POST",
     body: JSON.stringify(info),


### PR DESCRIPTION
**Which problem is this pull request solving?**

If for some reason the api token is missing, we want to fail early.

**List other issues or pull requests related to this problem**

https://github.com/netlify/build/issues/1816

**Describe the solution you've chosen**

throws an error

**Describe alternatives you've considered**

n/a

**Checklist**

- [x] The status checks are successful (continuous integration). Those can be seen below.
