### PR TITLE
Add support for `build.edge_handlers`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 .eslintcache
 .nyc_output
 coverage
+# Local Netlify folder
+.netlify

--- a/integration-test/.gitignore
+++ b/integration-test/.gitignore
@@ -1,2 +1,0 @@
-# Local Netlify folder
-.netlify

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,1 @@
 name: "@netlify/plugin-edge-handlers"
-inputs:
-  - name: sourceDir
-    default: "edge-handlers"

--- a/test/fixtures/config-dir/custom-edge-handlers/example.js
+++ b/test/fixtures/config-dir/custom-edge-handlers/example.js
@@ -1,0 +1,1 @@
+export function onRequest() {}

--- a/test/fixtures/config-dir/netlify.toml
+++ b/test/fixtures/config-dir/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+edge_handlers = "custom-edge-handlers"
+
+[[plugins]]
+package = "../../.."

--- a/test/main.js
+++ b/test/main.js
@@ -5,6 +5,8 @@ const { callHandler } = require("./helpers/handler");
 const { runNetlifyBuild } = require("./helpers/run");
 
 const INTEGRATION_TEST_DIR = `${__dirname}/../integration-test`;
+const FIXTURES_DIR = `${__dirname}/fixtures`;
+const CONFIG_FIXTURE_DIR = `${FIXTURES_DIR}/config-dir`;
 
 test("Edge handlers should be bundled", async (t) => {
   await runNetlifyBuild(t, INTEGRATION_TEST_DIR);
@@ -19,4 +21,11 @@ test("Edge handlers should be bundled", async (t) => {
     getRequest: () => ({ headers: { get: () => "AK" } }),
   });
   t.deepEqual(helloWorld.logs, "1,2,3,4,379");
+});
+
+test("Edge handlers directory can be configured using build.edge_handlers", async (t) => {
+  await runNetlifyBuild(t, CONFIG_FIXTURE_DIR);
+
+  const { manifest } = loadBundle(t, CONFIG_FIXTURE_DIR);
+  t.deepEqual(manifest.handlers, ["example"]);
 });


### PR DESCRIPTION
Fixes #55.

This allows users to configure the Edge handlers source directory using the `build.edge_handlers` configuration property (which is retrieved using `constants.EDGE_HANDLERS_SRC`).
This PR also includes an integration test for this feature.