### PR TITLE
Validate `build.edge_handlers` exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7521,13 +7521,9 @@
       }
     },
     "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "dev": true,
-      "requires": {
-        "pify": "^2.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -7869,6 +7865,17 @@
         "load-json-file": "^2.0.0",
         "normalize-package-data": "^2.3.2",
         "path-type": "^2.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        }
       }
     },
     "read-pkg-up": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^14.0.27",
     "make-dir": "^3.1.0",
     "node-fetch": "^2.6.1",
+    "path-type": "^4.0.0",
     "rollup": "^2.23.1",
     "typescript": "^3.9.7"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const commonjs = require("@rollup/plugin-commonjs");
 const json = require("@rollup/plugin-json");
 const nodeResolve = require("@rollup/plugin-node-resolve");
 const makeDir = require("make-dir");
+const { isDirectory } = require("path-type");
 const rollup = require("rollup");
 
 const babel = nodeBabel.babel;
@@ -165,6 +166,10 @@ function serializeHandler(handler) {
 
 module.exports = {
   onPostBuild: async ({ constants: { IS_LOCAL, NETLIFY_API_TOKEN, EDGE_HANDLERS_SRC }, utils }) => {
+    if (!(await isDirectory(EDGE_HANDLERS_SRC))) {
+      return utils.build.failBuild(`Edge handlers directory does not exist: ${EDGE_HANDLERS_SRC}`);
+    }
+
     const { mainFile, handlers } = await assemble(EDGE_HANDLERS_SRC);
 
     if (handlers.length === 0) {

--- a/test/fixtures/wrong-config-dir/netlify.toml
+++ b/test/fixtures/wrong-config-dir/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+edge_handlers = "does-not-exist"
+
+[[plugins]]
+package = "../../.."

--- a/test/main.js
+++ b/test/main.js
@@ -7,6 +7,7 @@ const { runNetlifyBuild } = require("./helpers/run");
 const INTEGRATION_TEST_DIR = `${__dirname}/../integration-test`;
 const FIXTURES_DIR = `${__dirname}/fixtures`;
 const CONFIG_FIXTURE_DIR = `${FIXTURES_DIR}/config-dir`;
+const WRONG_CONFIG_FIXTURE_DIR = `${FIXTURES_DIR}/wrong-config-dir`;
 
 test("Edge handlers should be bundled", async (t) => {
   await runNetlifyBuild(t, INTEGRATION_TEST_DIR);
@@ -28,4 +29,9 @@ test("Edge handlers directory can be configured using build.edge_handlers", asyn
 
   const { manifest } = loadBundle(t, CONFIG_FIXTURE_DIR);
   t.deepEqual(manifest.handlers, ["example"]);
+});
+
+test("Edge handlers directory build.edge_handlers misconfiguration is reported", async (t) => {
+  const { output } = await runNetlifyBuild(t, WRONG_CONFIG_FIXTURE_DIR, { expectedSuccess: false });
+  t.true(output.includes("does-not-exist"));
 });


### PR DESCRIPTION
Fixes #39.

If the user is configuring a custom `build.edge_handlers` property, but the path points to a non-existing file, this plugin currently fails with a `scandir: ...` error message, which is not clear. This PR adds a validation check to report this user error with a clearer message. It also includes an integration test.

Note: when `build.edge_handlers` is not specified, `constants.EDGE_HANDLERS_SRC` defaults to `"edge-handlers"`. However, this plugin is skipped if there is no `edge-handlers` directory. So that validation check only has an impact when the user configures `build.edge_handlers`.