### PR TITLE
Fix event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ function serializeHandler(handler) {
 }
 
 module.exports = {
-  onPostBuild: async ({ constants: { IS_LOCAL, NETLIFY_API_TOKEN, EDGE_HANDLERS_SRC }, utils }) => {
+  onBuild: async ({ constants: { IS_LOCAL, NETLIFY_API_TOKEN, EDGE_HANDLERS_SRC }, utils }) => {
     if (!(await isDirectory(EDGE_HANDLERS_SRC))) {
       return utils.build.failBuild(`Edge handlers directory does not exist: ${EDGE_HANDLERS_SRC}`);
     }


### PR DESCRIPTION
Background at https://github.com/netlify/build/issues/1796 and https://github.com/netlify/build/pull/1861.

We are changing the order in which core plugins run compared to user plugins for each event.

According to https://github.com/netlify/build/issues/1796, both Functions bundling and Edge handlers bundling run after the build command and `onBuild` events, but before `onPostBuild` events. This allows plugins to define logic both before (`onBuild`) and after (`onPostBuild`) bundling.

To achieve this, Functions bundling and Edge handlers bundling will now run at the end of `onBuild` (after user plugins) instead of at the beginning of `onPostBuild` (before user plugins). Since nothing happens between `onBuild` and `onPostBuild`, this is _exactly_ the same and does not change any behavior. Netlify Build enables this behavior behind a feature flag though to make sure that is the case.