### PR TITLE
Add `.js` to the bundle filename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,7 +142,7 @@ async function publishBundle(bundle, handlers, outputDir, isLocal, apiToken) {
 
   /** @type {import("./upload").BundleInfo} */
   const bundleInfo = {
-    sha: shasum.digest("hex"),
+    sha: `${shasum.digest("hex")}.js`,
     handlers,
     // needs to have length of the byte representation, not the string length
     content_length: buf.length,


### PR DESCRIPTION
Fixes #49.

This appends `.js` to the bundle filename.

On one hand, the bundle is merely an implementation detail, so we might want to keep it opaque.
On the other hand, many tools depends on knowing a file format using the file extension, so this might be a good practice. For example, when debugging a bundle, this would allow syntax highlighting in text editors and IDEs.