### PR TITLE
Fix Rollup warnings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,12 +112,14 @@ async function bundleFunctions(file, utils) {
         compact: true,
       }),
     ],
-    onwarn(msg) {
+    onwarn(msg, warn) {
       if (msg.code == "UNRESOLVED_IMPORT") {
-        utils.build.failBuild(
+        return utils.build.failBuild(
           `Error in ${msg.importer}, could not resolve ${msg.source} module. Please install this dependency locally and ensure it is listed in your package.json`,
         );
       }
+
+      warn(msg);
     },
   };
 


### PR DESCRIPTION
According to [the Rollup documentation](https://rollupjs.org/guide/en/#onwarn), the `onwarn` method should call the default `warn()` method (which is passed as argument) as a fallback. Otherwise, Rollup warnings are going to be silent instead of being printed in the build logs.