### PR TITLE
Improve error handling of Rollup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,14 +123,18 @@ async function bundleFunctions(file, utils) {
     },
   };
 
-  const bundle = await rollup.rollup(options);
-  const {
-    output: [{ code }],
-  } = await bundle.generate({
-    format: "iife",
-    compact: true,
-  });
-  return code;
+  try {
+    const bundle = await rollup.rollup(options);
+    const {
+      output: [{ code }],
+    } = await bundle.generate({
+      format: "iife",
+      compact: true,
+    });
+    return code;
+  } catch (error) {
+    return utils.build.failBuild("Error while bundling Edge handlers", { error });
+  }
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,8 @@ async function bundleFunctions(file, utils) {
     });
     return code;
   } catch (error) {
+    // This will stop the execution of this plugin.
+    // No Edge handlers will be uploaded.
     return utils.build.failBuild("Error while bundling Edge handlers", { error });
   }
 }

--- a/test/fixtures/syntax-error/edge-handlers/example.js
+++ b/test/fixtures/syntax-error/edge-handlers/example.js
@@ -1,0 +1,2 @@
+// Intentional JavaScript error
+exportt function onRequest() {}

--- a/test/fixtures/syntax-error/netlify.toml
+++ b/test/fixtures/syntax-error/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "../../.."

--- a/test/main.js
+++ b/test/main.js
@@ -8,6 +8,7 @@ const FIXTURES_DIR = `${__dirname}/fixtures`;
 const INTEGRATION_TEST_DIR = `${FIXTURES_DIR}/integration-test`;
 const CONFIG_FIXTURE_DIR = `${FIXTURES_DIR}/config-dir`;
 const WRONG_CONFIG_FIXTURE_DIR = `${FIXTURES_DIR}/wrong-config-dir`;
+const SYNTAX_ERROR_FIXTURE_DIR = `${FIXTURES_DIR}/syntax-error`;
 
 test("Edge handlers should be bundled", async (t) => {
   await runNetlifyBuild(t, INTEGRATION_TEST_DIR);
@@ -34,4 +35,9 @@ test("Edge handlers directory can be configured using build.edge_handlers", asyn
 test("Edge handlers directory build.edge_handlers misconfiguration is reported", async (t) => {
   const { output } = await runNetlifyBuild(t, WRONG_CONFIG_FIXTURE_DIR, { expectedSuccess: false });
   t.true(output.includes("does-not-exist"));
+});
+
+test("Edge handlers directory build.edge_handlers syntax error is reported", async (t) => {
+  const { output } = await runNetlifyBuild(t, SYNTAX_ERROR_FIXTURE_DIR, { expectedSuccess: false });
+  t.true(output.includes("Error while bundling"));
 });


### PR DESCRIPTION
Fixes #69.

If a Edge handler source file has a syntax error, Rollup will fail.
This should be handled and reported as a user error (using `utils.build.failBuild()`) instead of a plugin error.