### PR TITLE
Compact bundle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,6 +128,7 @@ async function bundleFunctions(file, utils) {
     output: [{ code }],
   } = await bundle.generate({
     format: "iife",
+    compact: true,
   });
   return code;
 }


### PR DESCRIPTION
Part of #73.

This uses the [`compact`](https://rollupjs.org/guide/en/#outputcompact) option of Rollup.