### PR TITLE
Simplify retrieving test fixtures

### DIFF
--- a/test/helpers/bundle.js
+++ b/test/helpers/bundle.js
@@ -1,17 +1,19 @@
 const isPlainObj = require("is-plain-obj");
 const sinon = require("sinon");
 
+const { resolveFixtureName } = require("./fixtures");
 const { normalizeHandler, isValidHandler } = require("./handler");
 
 // Retrieve Edge handlers bundled handlers
-const loadBundle = function (t, fixtureDir) {
-  const { manifest, bundlePath } = loadManifest(t, fixtureDir);
+const loadBundle = function (t, fixtureName) {
+  const { manifest, bundlePath } = loadManifest(t, fixtureName);
   const handlers = requireBundle(t, bundlePath);
   return { manifest, handlers };
 };
 
 // Load Edge handlers `manifest.json`
-const loadManifest = function (t, fixtureDir) {
+const loadManifest = function (t, fixtureName) {
+  const fixtureDir = resolveFixtureName(fixtureName);
   const localOutDir = `${fixtureDir}/.netlify/edge-handlers`;
   const manifestPath = `${localOutDir}/manifest.json`;
   const manifest = require(manifestPath);

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -1,0 +1,8 @@
+const FIXTURES_DIR = `${__dirname}/../fixtures`;
+
+// Resolve fixture name to an absolute path
+const resolveFixtureName = function (fixtureName) {
+  return `${FIXTURES_DIR}/${fixtureName}`;
+};
+
+module.exports = { resolveFixtureName };

--- a/test/helpers/run.js
+++ b/test/helpers/run.js
@@ -5,12 +5,15 @@ env.FORCE_COLOR = "1";
 
 const netlifyBuild = require("@netlify/build");
 
+const { resolveFixtureName } = require("./fixtures");
+
 // Run @netlify/build on a specific fixture directory
 // Retrieve:
 //  - `success` {boolean}: whether build succeeded
 //  - `output` {string}: build logs
-const runNetlifyBuild = async function (t, fixtureDir, { expectedSuccess = true } = {}) {
-  const { success, logs } = await netlifyBuild({ cwd: fixtureDir, buffer: true, telemetry: false });
+const runNetlifyBuild = async function (t, fixtureName, { expectedSuccess = true } = {}) {
+  const cwd = resolveFixtureName(fixtureName);
+  const { success, logs } = await netlifyBuild({ cwd, buffer: true, telemetry: false });
   const output = serializeOutput(logs);
   printOutput({ output, success, expectedSuccess });
   t.is(success, expectedSuccess);

--- a/test/main.js
+++ b/test/main.js
@@ -4,16 +4,10 @@ const { loadBundle } = require("./helpers/bundle");
 const { callHandler } = require("./helpers/handler");
 const { runNetlifyBuild } = require("./helpers/run");
 
-const FIXTURES_DIR = `${__dirname}/fixtures`;
-const INTEGRATION_TEST_DIR = `${FIXTURES_DIR}/integration-test`;
-const CONFIG_FIXTURE_DIR = `${FIXTURES_DIR}/config-dir`;
-const WRONG_CONFIG_FIXTURE_DIR = `${FIXTURES_DIR}/wrong-config-dir`;
-const SYNTAX_ERROR_FIXTURE_DIR = `${FIXTURES_DIR}/syntax-error`;
-
 test("Edge handlers should be bundled", async (t) => {
-  await runNetlifyBuild(t, INTEGRATION_TEST_DIR);
+  await runNetlifyBuild(t, "integration-test");
 
-  const { manifest, handlers } = loadBundle(t, INTEGRATION_TEST_DIR);
+  const { manifest, handlers } = loadBundle(t, "integration-test");
   t.deepEqual(manifest.handlers.sort(), ["example", "hello-world"]);
 
   const example = await callHandler(t, handlers, "example");
@@ -26,18 +20,18 @@ test("Edge handlers should be bundled", async (t) => {
 });
 
 test("Edge handlers directory can be configured using build.edge_handlers", async (t) => {
-  await runNetlifyBuild(t, CONFIG_FIXTURE_DIR);
+  await runNetlifyBuild(t, "config-dir");
 
-  const { manifest } = loadBundle(t, CONFIG_FIXTURE_DIR);
+  const { manifest } = loadBundle(t, "config-dir");
   t.deepEqual(manifest.handlers, ["example"]);
 });
 
 test("Edge handlers directory build.edge_handlers misconfiguration is reported", async (t) => {
-  const { output } = await runNetlifyBuild(t, WRONG_CONFIG_FIXTURE_DIR, { expectedSuccess: false });
+  const { output } = await runNetlifyBuild(t, "wrong-config-dir", { expectedSuccess: false });
   t.true(output.includes("does-not-exist"));
 });
 
 test("Edge handlers directory build.edge_handlers syntax error is reported", async (t) => {
-  const { output } = await runNetlifyBuild(t, SYNTAX_ERROR_FIXTURE_DIR, { expectedSuccess: false });
+  const { output } = await runNetlifyBuild(t, "syntax-error", { expectedSuccess: false });
   t.true(output.includes("Error while bundling"));
 });


### PR DESCRIPTION
Each time a new fixture directory is created, we have to add a new constant pointing to its file path. This PR simplifies this pattern so integration tests can refer to a fixture directory by its sole filename instead.