### PR TITLE
Small simplification of code generation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,9 +42,8 @@ async function assemble(EDGE_HANDLERS_SRC) {
 
   const imports = [];
   const registration = [];
-  for (const handler of handlers) {
-    const id = `func${getShasum(Buffer.from(handler))}`;
-
+  for (const [index, handler] of handlers.entries()) {
+    const id = `func${index}`;
     imports.push(`import * as ${id} from "${unixify(path.resolve(EDGE_HANDLERS_SRC, handler))}";`);
     registration.push(`netlifyRegistry.set("${handler}", ${id});`);
   }


### PR DESCRIPTION
This is a small follow-up on https://github.com/netlify/netlify-plugin-edge-handlers/pull/79#issuecomment-699144530

Each Edge handler is stored to a variable which is then passed to `netlifyRegistry.set()`. That variable is local to the bundle, i.e. its name is not important. Actually with #79, that name will be minified. 

The only constraint is that each Edge handler in a given bundle should use a unique variable name. At the moment, we do this by hashing the Edge handler filename. This PR implements using an incremental integer instead, which is simpler and more CPU-efficient.

This does not have an impact on the the bundle filename being consistent (#66): it will still reflect whether the Edge handler contents or filenames have changed.