### PR TITLE
Small refactoring of bundle generation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,14 +40,13 @@ async function assemble(EDGE_HANDLERS_SRC) {
     return { handlers };
   }
 
-  const imports = [];
-  const registration = [];
-  for (const [index, handler] of handlers.entries()) {
-    const id = `func${index}`;
-    imports.push(`import * as ${id} from "${unixify(path.resolve(EDGE_HANDLERS_SRC, handler))}";`);
-    registration.push(`netlifyRegistry.set("${handler}", ${id});`);
-  }
-  const mainContents = imports.concat(registration).join("\n");
+  const mainContents = handlers
+    .map(
+      (handler, index) => `
+import * as func${index} from "${unixify(path.resolve(EDGE_HANDLERS_SRC, handler))}";
+netlifyRegistry.set("${handler}", func${index});`,
+    )
+    .join("\n");
 
   const tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "handlers-")); //make temp dir `handlers-abc123`
   const mainFile = path.join(tmpDir, MAIN_FILE);


### PR DESCRIPTION
This is a small refactoring of the bundle generation logic.
This is meant to make it a little simpler. Please let me know if you think this is clearer or not.

Note: it changes the order of the `import` and `netlifyRegistry.set()` statements, but this should not change the behavior.