### PR TITLE
Output (in CLI) which module failed to be included

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -172,7 +172,9 @@ function bundleFunctionsForCli(file) {
       if (msg.code == "UNRESOLVED_IMPORT") {
         rej({
           code: "unresolved-import",
-          msg: `Error in ${msg.importer}, could not resolve ${msg.source} module. Please install this dependency locally and ensure it is listed in your package.json`,
+          msg: `Error in ${msg.importer}, could not resolve ${msg.source} module. Please install this dependency locally and ensure it is listed in your package.json.`,
+          importee: msg.source,
+          importer: msg.importer,
           success: false,
         });
       } else {

--- a/test/fixtures/missing-modules/edge-handlers/test.js
+++ b/test/fixtures/missing-modules/edge-handlers/test.js
@@ -1,0 +1,3 @@
+import 'gatsby';
+
+export const onRequest = () => {};

--- a/test/main.js
+++ b/test/main.js
@@ -52,3 +52,11 @@ test("Edge handlers CLI build bundles custom directories", async (t) => {
   t.true(success, `failed bundling integration test (${code}): ${msg}`);
   t.true(handlers.length > 0, "did not include any handlers");
 });
+
+test("Edge handlers CLI outputs missing imports", async (t) => {
+  const { code, importee, importer, msg, success } = await runCliBuild("missing-modules");
+  t.false(success, `failed bundling integration test (${code}): ${msg}`);
+  t.is(importee, "gatsby");
+  t.true(importer.length > 0);
+  t.true(importer.endsWith(".js"));
+});


### PR DESCRIPTION
**Which problem is this pull request solving?**

This will allow us to syntax-highlight the modules that were missing in `netlify dev`.

**Describe the solution you've chosen**

We now output their names and the module that included them in the JSON payload.

**Describe alternatives you've considered**

We could also parse the error message but in what world would we live if we had to resort to that.

**Checklist**

Please add a `x` inside each checkbox:

- [X] The status checks are successful (continuous integration). Those can be seen below.
- [X] Added tests.
