### PR TITLE
Align casing of "Edge Handlers" term

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ build, meaning that any handler under the `./edge-handlers` directory will be bu
 This plugin is already integrated into Netlify's build process and will not need to be included in your project for Edge
 Handlers to work.
 
-To run this plugin locally in an existing project that has edge handlers, you'll need to install the netlify build
+To run this plugin locally in an existing project that has Edge Handlers, you'll need to install the netlify build
 codebase locally and symlink this plugin to that repo. To do so:
 
 1. Clone the build repo and install dependencies

--- a/src/cli.js
+++ b/src/cli.js
@@ -30,7 +30,7 @@ const build = async ({ EDGE_HANDLERS_SRC }) => {
     console.log(
       JSON.stringify({
         code: "unknown",
-        msg: `Failed discovering edge handlers: ${err.message}`,
+        msg: `Failed discovering Edge Handlers: ${err.message}`,
         success: false,
       }),
     );
@@ -53,7 +53,7 @@ const build = async ({ EDGE_HANDLERS_SRC }) => {
 const main = async () => {
   const [, bin, command, EDGE_HANDLERS_SRC] = process.argv;
 
-  const USAGE = `Usage: ${bin} build <edge handlers directory>`;
+  const USAGE = `Usage: ${bin} build <Edge Handlers directory>`;
 
   if (command !== "build") {
     console.log(
@@ -68,7 +68,7 @@ const main = async () => {
     console.log(
       JSON.stringify({
         code: "cli",
-        msg: `You must specify the edge handlers source directory\n\n${USAGE}`,
+        msg: `You must specify the Edge Hhandlers source directory\n\n${USAGE}`,
         success: false,
       }),
     );

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,12 @@ const { assemble, bundleFunctions, logHandlers, publishBundle } = require("./lib
 module.exports = {
   onBuild: async ({ constants: { IS_LOCAL, NETLIFY_API_TOKEN, EDGE_HANDLERS_SRC }, utils }) => {
     if (!(await isDirectory(EDGE_HANDLERS_SRC))) {
-      return utils.build.failBuild(`Edge handlers directory does not exist: ${path.resolve(EDGE_HANDLERS_SRC)}`);
+      return utils.build.failBuild(`Edge Handlers directory does not exist: ${path.resolve(EDGE_HANDLERS_SRC)}`);
     }
     const { mainFile, handlers } = await assemble(EDGE_HANDLERS_SRC);
 
     if (handlers.length === 0) {
-      console.log(`No Edge handlers were found in ${EDGE_HANDLERS_SRC} directory`);
+      console.log(`No Edge Handlers were found in ${EDGE_HANDLERS_SRC} directory`);
       return;
     }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -155,8 +155,8 @@ async function bundleFunctions(file, utils) {
     return code;
   } catch (error) {
     // This will stop the execution of this plugin.
-    // No Edge handlers will be uploaded.
-    return utils.build.failBuild("Error while bundling Edge handlers", { error });
+    // No Edge Handlers will be uploaded.
+    return utils.build.failBuild("Error while bundling Edge Handlers", { error });
   }
 }
 
@@ -194,7 +194,7 @@ function bundleFunctionsForCli(file) {
       .catch((err) =>
         rej({
           code: "unknown",
-          msg: `Error while bundling edge handlers: ${err.message}`,
+          msg: `Error while bundling Edge Handlers: ${err.message}`,
           success: false,
         }),
       );
@@ -251,7 +251,7 @@ async function publishBundle(bundle, handlers, outputDir, isLocal, apiToken) {
 
 function logHandlers(handlers, EDGE_HANDLERS_SRC) {
   const handlersString = handlers.map(serializeHandler).join("\n");
-  console.log(`Packaging Edge handlers from ${EDGE_HANDLERS_SRC} directory:\n${handlersString}`);
+  console.log(`Packaging Edge Handlers from ${EDGE_HANDLERS_SRC} directory:\n${handlersString}`);
 }
 
 function serializeHandler(handler) {

--- a/test/helpers/bundle.js
+++ b/test/helpers/bundle.js
@@ -4,14 +4,14 @@ const sinon = require("sinon");
 const { resolveFixtureName } = require("./fixtures");
 const { normalizeHandler, isValidHandler } = require("./handler");
 
-// Retrieve Edge handlers bundled handlers
+// Retrieve Edge Handlers bundled handlers
 const loadBundle = function (t, fixtureName) {
   const { manifest, bundlePath } = loadManifest(t, fixtureName);
   const handlers = requireBundle(t, bundlePath);
   return { manifest, handlers };
 };
 
-// Load Edge handlers `manifest.json`
+// Load Edge Handlers `manifest.json`
 const loadManifest = function (t, fixtureName) {
   const fixtureDir = resolveFixtureName(fixtureName);
   const localOutDir = `${fixtureDir}/.netlify/edge-handlers`;

--- a/test/main.js
+++ b/test/main.js
@@ -4,7 +4,7 @@ const { loadBundle } = require("./helpers/bundle");
 const { callHandler } = require("./helpers/handler");
 const { runCliBuild, runNetlifyBuild } = require("./helpers/run");
 
-test("Edge handlers should be bundled", async (t) => {
+test("Edge Handlers should be bundled", async (t) => {
   await runNetlifyBuild(t, "integration-test");
 
   const { manifest, handlers } = loadBundle(t, "integration-test");
@@ -19,41 +19,41 @@ test("Edge handlers should be bundled", async (t) => {
   t.deepEqual(helloWorld.logs, "1,2,3,4,379");
 });
 
-test("Edge handlers directory can be configured using build.edge_handlers", async (t) => {
+test("Edge Handlers directory can be configured using build.edge_handlers", async (t) => {
   await runNetlifyBuild(t, "config-dir");
 
   const { manifest } = loadBundle(t, "config-dir");
   t.deepEqual(manifest.handlers, ["example"]);
 });
 
-test("Edge handlers directory build.edge_handlers misconfiguration is reported", async (t) => {
+test("Edge Handlers directory build.edge_handlers misconfiguration is reported", async (t) => {
   const { output } = await runNetlifyBuild(t, "wrong-config-dir", { expectedSuccess: false });
   t.true(output.includes("does-not-exist"));
 });
 
-test("Edge handlers directory build.edge_handlers syntax error is reported", async (t) => {
+test("Edge Handlers directory build.edge_handlers syntax error is reported", async (t) => {
   const { output } = await runNetlifyBuild(t, "syntax-error", { expectedSuccess: false });
   t.true(output.includes("Error while bundling"));
 });
 
-test("Edge handlers CLI build works", async (t) => {
+test("Edge Handlers CLI build works", async (t) => {
   const { code, handlers, msg, success } = await runCliBuild("integration-test");
   t.true(success, `failed bundling integration test (${code}): ${msg}`);
   t.true(handlers.length > 0, "did not include any handlers");
 });
 
-test("Edge handlers CLI build errors on syntax error", async (t) => {
+test("Edge Handlers CLI build errors on syntax error", async (t) => {
   const { code, msg, success } = await runCliBuild("syntax-error");
   t.false(success, `successfully bundled broken test (${code}): ${msg}`);
 });
 
-test("Edge handlers CLI build bundles custom directories", async (t) => {
+test("Edge Handlers CLI build bundles custom directories", async (t) => {
   const { code, handlers, msg, success } = await runCliBuild("config-dir", "custom-edge-handlers");
   t.true(success, `failed bundling integration test (${code}): ${msg}`);
   t.true(handlers.length > 0, "did not include any handlers");
 });
 
-test("Edge handlers CLI outputs missing imports", async (t) => {
+test("Edge Handlers CLI outputs missing imports", async (t) => {
   const { code, importee, importer, msg, success } = await runCliBuild("missing-modules");
   t.false(success, `failed bundling integration test (${code}): ${msg}`);
   t.is(importee, "gatsby");


### PR DESCRIPTION
**Which problem is this pull request solving?**

This PR aligns the casing of the term "Edge Handlers" to capital case to stay consistent with the rest of the product. "Edge Handlers" is also a name.

**List other issues or pull requests related to this problem**

https://github.com/netlify/cli/pull/1461

**Checklist**

Please add a `x` inside each checkbox:

- [X] The status checks are successful (continuous integration). Those can be seen below.
