### PR TITLE
feat(docs): add contribution guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,60 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making
+participation in our project and our community a harassment-free experience for everyone, regardless of age, body size,
+disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take
+appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits,
+issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the
+project or its community. Examples of representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed representative at an online or offline
+event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at
+david@netlify.com. All complaints will be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to
+the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent
+repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at
+[http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# CONTRIBUTING
+
+Contributions are always welcome, no matter how large or small. Before contributing, please read the
+[code of conduct](CODE_OF_CONDUCT.md).
+
+## Setup
+
+> Install Node.js + npm on your system: https://nodejs.org/en/download/
+
+```sh
+git clone git@github.com:netlify/netlify-plugin-edge-handlers.git
+cd netlify-plugin-edge-handlers
+npm install
+npm test
+```
+
+## Testing
+
+To run tests in this plugin, simply run:
+
+```sh
+npm test
+```
+
+This will run formatting, linting and the integration tests located in the `test` folder.
+
+## Releasing
+
+1. Merge the release PR
+2. Switch to the default branch `git checkout master`
+3. Pull latest changes `git pull`
+4. Publish the package `npm publish`
+
+## License
+
+By contributing to Netlify Node Client, you agree that your contributions will be licensed under its
+[MIT license](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ Contributions are always welcome, no matter how large or small. Before contribut
 git clone git@github.com:netlify/netlify-plugin-edge-handlers.git
 cd netlify-plugin-edge-handlers
 npm install
-npm test
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ codebase locally and symlink this plugin to that repo. To do so:
 
 1. Clone the build repo and install dependencies
 
-```
+```sh
 git clone git@github.com:netlify/build.git
 
 npm i
@@ -27,16 +27,6 @@ npm i
 
 4. Run the plugin locally in your project by typing in your project directory:
 
-```
+```sh
 /path/to/netlify-build/packages/build/src/core/bin.js
 ```
-
-## Testing
-
-To run tests in this plugin, simply run:
-
-```
-npm run test
-```
-
-This will start the integration tests located in the `integration-test` folder.


### PR DESCRIPTION
This should be merged after https://github.com/netlify/netlify-plugin-edge-handlers/pull/109 as the documented release flow is based on that PR.

Fixes https://github.com/netlify/netlify-plugin-edge-handlers/issues/89