### PR TITLE
chore: add renovate bot

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,14 @@
+{
+  extends: ["github>netlify/renovate-config:default"],
+  ignorePresets: [":prHourlyLimit2"],
+  semanticCommits: true,
+  masterIssue: true,
+  packageRules: [
+    {
+      // update Netlify packages immediately
+      packagePatterns: ["^@netlify", "^netlify"],
+      groupName: "netlify packages",
+      schedule: null,
+    },
+  ],
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,13 +2,5 @@
   extends: ["github>netlify/renovate-config:default"],
   ignorePresets: [":prHourlyLimit2"],
   semanticCommits: true,
-  masterIssue: true,
-  packageRules: [
-    {
-      // update Netlify packages immediately
-      packagePatterns: ["^@netlify", "^netlify"],
-      groupName: "netlify packages",
-      schedule: null,
-    },
-  ],
+  masterIssue: true
 }


### PR DESCRIPTION
**Which problem is this pull request solving?**

Many of the plugin's dependencies are out of date, see `npm outdated` result:
```
Package                      Current    Wanted    Latest  Location
@babel/core                   7.11.4   7.12.10   7.12.10  @netlify/plugin-edge-handlers
@babel/preset-env             7.11.5   7.12.11   7.12.11  @netlify/plugin-edge-handlers
@netlify/build                 4.1.1     4.8.4     8.0.0  @netlify/plugin-edge-handlers
@rollup/plugin-babel           5.2.0     5.2.2     5.2.2  @netlify/plugin-edge-handlers
@rollup/plugin-commonjs       15.0.0    15.1.0    17.0.0  @netlify/plugin-edge-handlers
@rollup/plugin-node-resolve    9.0.0     9.0.0    11.0.1  @netlify/plugin-edge-handlers
@types/node                  14.0.27  14.14.19  14.14.19  @netlify/plugin-edge-handlers
ava                           3.12.1    3.15.0    3.15.0  @netlify/plugin-edge-handlers
del                            5.1.0     5.1.0     6.0.0  @netlify/plugin-edge-handlers
eslint                         7.7.0    7.17.0    7.17.0  @netlify/plugin-edge-handlers
eslint-config-prettier        6.11.0    6.15.0     7.1.0  @netlify/plugin-edge-handlers
eslint-plugin-import          2.22.0    2.22.1    2.22.1  @netlify/plugin-edge-handlers
eslint-plugin-prettier         3.1.4     3.3.0     3.3.0  @netlify/plugin-edge-handlers
is-plain-obj                   2.1.0     2.1.0     3.0.0  @netlify/plugin-edge-handlers
prettier                       2.1.1     2.2.1     2.2.1  @netlify/plugin-edge-handlers
rollup                        2.23.1    2.35.1    2.35.1  @netlify/plugin-edge-handlers
sinon                          9.0.3     9.2.2     9.2.2  @netlify/plugin-edge-handlers
typescript                     3.9.7     3.9.7     4.1.3  @netlify/plugin-edge-handlers
``` 

**Describe the solution you've chosen**

Use renovate bot to handle updates

**Describe alternatives you've considered**

dependabot? We use renovate for many of our Node.js projects

**Checklist**

Please add a `x` inside each checkbox:

- [x] The status checks are successful (continuous integration). Those can be seen below.
