### PR TITLE
Reduce npm package size from 117KB to 7KB

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.github/
-.editorconfig
-.eslint*
-.prettierrc.json
-
-test/
-ava.config.js
-
-*.tgz

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "files": [
     "src",
-    "!*~",
     "manifest.yml"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "bin": {
     "plugin-build-edge-handlers": "src/cli.js"
   },
+  "files": [
+    "src",
+    "!*~",
+    "manifest.yml"
+  ],
   "scripts": {
     "test": "npm run format && npm run test:dev",
     "format": "run-s format:*",


### PR DESCRIPTION
Before:

```
$ npm pack --dry
 
 📦  @netlify/plugin-edge-handlers@1.11.1
 === Tarball Contents === 
 27B     .gitignore~                                                                     
 577.8kB integration-test/.netlify/edge-handlers/b3878d007ab6427f59026e6127830bba627d216d
 1.1kB   LICENSE                                                                         
 27B     src/node-compat/assets/browser.js                                               
 1.8kB   src/cli.js                                                                      
 66B     commitlint.config.js                                                            
 278B    src/consts.js                                                                   
 1.4kB   src/node-compat/globals.js                                                      
 1.4kB   src/index.js                                                                    
 7.4kB   src/lib.js                                                                      
 1.5kB   src/upload.js                                                                   
 39B     ava.config.js~                                                                  
 3.1kB   index.js~                                                                       
 6.5kB   src/index.js~                                                                   
 181B    integration-test/.netlify/edge-handlers/manifest.json                           
 2.3kB   package.json                                                                    
 2.0kB   package.json~                                                                   
 142B    renovate.json5                                                                  
 1.2kB   CHANGELOG.md                                                                    
 3.2kB   CODE_OF_CONDUCT.md                                                              
 827B    CONTRIBUTING.md                                                                 
 1.2kB   README.md                                                                       
 38B     manifest.yml                                                                    
 95B     manifest.yml~                                                                   
 === Tarball Details === 
 name:          @netlify/plugin-edge-handlers           
 version:       1.11.1                                  
 package size:  117.1 kB                                
 unpacked size: 613.7 kB                                
 shasum:        56faba27709cddf05d59091d4377088499c56f78
 integrity:     sha512-zuEd804TH9PCw[...]hez7gmpEQMkqA==
 total files:   24                                      
```

After:

```
$ npm pack --dry
 
 📦  @netlify/plugin-edge-handlers@1.11.1
 === Tarball Contents === 
 1.1kB LICENSE                          
 27B   src/node-compat/assets/browser.js
 1.8kB src/cli.js                       
 278B  src/consts.js                    
 1.4kB src/node-compat/globals.js       
 1.4kB src/index.js                     
 7.4kB src/lib.js                       
 1.5kB src/upload.js                    
 2.4kB package.json                     
 1.2kB CHANGELOG.md                     
 1.2kB README.md                        
 38B   manifest.yml                     
 === Tarball Details === 
 name:          @netlify/plugin-edge-handlers           
 version:       1.11.1                                  
 filename:      netlify-plugin-edge-handlers-1.11.1.tgz 
 package size:  7.3 kB                                  
 unpacked size: 19.8 kB                                 
 shasum:        2db49809520a0110511cdd67f675ca098d66c100
 integrity:     sha512-Rl6SvBr1a3Gm6[...]WY28FUGZTj5dA==
 total files:   12                                      
```