### PR TITLE
chore: do not upgrade `path-type`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,5 +2,16 @@
   extends: ["github>netlify/renovate-config:default"],
   ignorePresets: [":prHourlyLimit2"],
   semanticCommits: true,
-  masterIssue: true
+  masterIssue: true,
+  packageRules: [
+    {
+      // Those cannot be upgraded to a major version until we drop support for Node 10
+      packageNames: [
+        'path-type',
+      ],
+      major: {
+        enabled: false,
+      },
+    },
+  ],
 }


### PR DESCRIPTION
See https://github.com/netlify/netlify-plugin-edge-handlers/pull/167

`path-type` should not be automatically upgraded because it drops support for Node 10.