### PR TITLE
fix: fix `files` in `package.json` with npm v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "plugin-build-edge-handlers": "src/cli.js"
   },
   "files": [
-    "src",
+    "src/**/*.js",
     "manifest.yml"
   ],
   "scripts": {


### PR DESCRIPTION
npm 7 changed the way globbing patterns are interpreted in `files` in `package.json`. This is undocumented, so I'm not sure whether this is a bug or not. This results in all `*~` files (Vim temporary files) to be published to npm, which can double the package size. 

This PR fixes this. I ran `npm pack --dry` before and after to ensure no files were being omitted.