### PR TITLE
codeowners delivery => runtime

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @netlify/delivery
+* @netlify/runtime


### PR DESCRIPTION
(The `delivery` team has been renamed to `runtime` to follow the pod rename).