### PR TITLE
chore: add PR labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,26 @@
+name: Label PR
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  label-pr:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pr:
+          [
+            { prefix: 'fix', type: 'bug' },
+            { prefix: 'chore', type: 'chore' },
+            { prefix: 'test', type: 'chore' },
+            { prefix: 'ci', type: 'chore' },
+            { prefix: 'feat', type: 'feature' },
+            { prefix: 'security', type: 'security' },
+          ]
+    steps:
+      - uses: netlify/pr-labeler-action@v1.0.0
+        if: startsWith(github.event.pull_request.title, matrix.pr.prefix)
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          label: 'type: ${{ matrix.pr.type }}'


### PR DESCRIPTION
This should allow renovate to automerge dependency PRs by making the PR label status check pass.