### PR TITLE
chore: Update mention of default edge handlers folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Netlify Plugin Edge Handlers
 
 This plugin is used to bundle Edge Handlers for deployment. It is included in the list of core plugins in Netlify's
-build, meaning that any handler under the `./edge-handlers` directory will be bundled by Netlify's buildbot.
+build, meaning that any handler under the `netlify/edge-handlers` directory will be bundled by Netlify's buildbot.
 
 ## Usage
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

Going forward, we will change the directory we load edge handlers from.

**List other issues or pull requests related to this problem**

https://github.com/netlify/traffic-mesh/issues/1492#issuecomment-809776782

**Checklist**

Please add a `x` inside each checkbox:

- [X] The status checks are successful (continuous integration). Those can be seen below.
