### PR TITLE
chore(renovate): ignore major updates for 'is-plain-obj'

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,6 +8,7 @@
       // Those cannot be upgraded to a major version until we drop support for Node 10
       packageNames: [
         'path-type',
+        'is-plain-obj',
       ],
       major: {
         enabled: false,


### PR DESCRIPTION
This should autoclose https://github.com/netlify/netlify-plugin-edge-handlers/pull/265