### PR TITLE
fix(api): rely on build's provided NETLIFY_API_HOST

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -4,4 +4,3 @@ exports.LOCAL_OUT_DIR = path.join(process.cwd(), ".netlify", "edge-handlers");
 exports.MANIFEST_FILE = "manifest.json";
 exports.MAIN_FILE = "__netlifyMain.ts";
 exports.CONTENT_TYPE = "application/javascript";
-exports.API_HOST = "api.netlify.com";

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const { LOCAL_OUT_DIR } = require("./consts");
 const { assemble, bundleFunctions, logHandlers, publishBundle } = require("./lib");
 
 module.exports = {
-  onBuild: async ({ constants: { IS_LOCAL, NETLIFY_API_TOKEN, EDGE_HANDLERS_SRC }, utils }) => {
+  onBuild: async ({ constants: { IS_LOCAL, NETLIFY_API_TOKEN, NETLIFY_API_HOST, EDGE_HANDLERS_SRC }, utils }) => {
     if (!(await isDirectory(EDGE_HANDLERS_SRC))) {
       return utils.build.failBuild(`Edge Handlers directory does not exist: ${path.resolve(EDGE_HANDLERS_SRC)}`);
     }
@@ -20,7 +20,14 @@ module.exports = {
 
     logHandlers(handlers, EDGE_HANDLERS_SRC);
     const bundle = await bundleFunctions(mainFile, utils);
-    const uploaded = await publishBundle(bundle, handlers, LOCAL_OUT_DIR, IS_LOCAL, NETLIFY_API_TOKEN);
+    const uploaded = await publishBundle(
+      bundle,
+      handlers,
+      LOCAL_OUT_DIR,
+      IS_LOCAL,
+      NETLIFY_API_HOST,
+      NETLIFY_API_TOKEN,
+    );
 
     if (!IS_LOCAL) {
       const summaryText = uploaded

--- a/src/lib.js
+++ b/src/lib.js
@@ -208,10 +208,11 @@ function bundleFunctionsForCli(file) {
  * @param {string[]} handlers names of the included handlers
  * @param {string} outputDir path to the output directory (created if not exists)
  * @param {boolean} isLocal whether we're running locally or in CI
+ * @param {string} apiHost Netlify API host used for uploads
  * @param {string | null} apiToken Netlify API token used for uploads
  * @returns {Promise<boolean>}
  */
-async function publishBundle(bundle, handlers, outputDir, isLocal, apiToken) {
+async function publishBundle(bundle, handlers, outputDir, isLocal, apiHost, apiToken) {
   // encode bundle into bytes
   const buf = Buffer.from(bundle, "utf-8");
   const sha = getShasum(buf);
@@ -239,7 +240,7 @@ async function publishBundle(bundle, handlers, outputDir, isLocal, apiToken) {
     const manifestFile = path.join(outputDir, MANIFEST_FILE);
     await fsPromises.writeFile(manifestFile, JSON.stringify(bundleInfo, null, 2));
   } else {
-    const uploaded = await uploadBundle(buf, bundleInfo, process.env.DEPLOY_ID, apiToken);
+    const uploaded = await uploadBundle(buf, bundleInfo, process.env.DEPLOY_ID, apiHost, apiToken);
     if (!uploaded) {
       console.log("Bundle already exists. Skipping upload...");
     }

--- a/src/upload.js
+++ b/src/upload.js
@@ -1,6 +1,6 @@
 const fetch = require("node-fetch");
 
-const { API_HOST, CONTENT_TYPE } = require("./consts");
+const { CONTENT_TYPE } = require("./consts");
 
 /**
  * @typedef {{ sha: string, handlers: string[], content_length: number, content_type: string }} BundleInfo
@@ -12,15 +12,16 @@ const { API_HOST, CONTENT_TYPE } = require("./consts");
  * @param {Buffer} buf UTF-8 encoded handler bundle
  * @param {BundleInfo} info metadata about the bundle
  * @param {string} deployId id of the deploy the bundle is deployed for
+ * @param {string} apiHost  host of the Netlify API
  * @param {string} apiToken token for authorizing on the API
  * @returns {Promise<boolean>} Whether the bundle was newly uploaded (and did not already exist)
  */
-async function uploadBundle(buf, info, deployId, apiToken) {
+async function uploadBundle(buf, info, deployId, apiHost, apiToken) {
   if (!apiToken) {
     throw new Error("API token is missing");
   }
 
-  const resp = await fetch(`https://${API_HOST}/api/v1/deploys/${deployId}/edge_handlers`, {
+  const resp = await fetch(`https://${apiHost}/api/v1/deploys/${deployId}/edge_handlers`, {
     method: "POST",
     body: JSON.stringify(info),
     headers: {


### PR DESCRIPTION
**Which problem is this pull request solving?**

Follow up on https://github.com/netlify/build/pull/2709, so that the plugin relies on the API host passed to `build`.
