### PR TITLE
fix(actions): change branches from master to main

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -3,7 +3,7 @@ name: Dependency License Scanning
 on:
   push:
     branches:
-      - master
+      - main
 
 defaults:
   run:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: release-please
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   # Ensure GitHub actions are not run twice for same commits
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
     types: [opened, synchronize, reopened]

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   extends: ["github>netlify/renovate-config:default"],
   ignorePresets: [":prHourlyLimit2"],
   semanticCommits: true,
-  masterIssue: true,
+  dependencyDashboard: true,
   packageRules: [
     {
       // Those cannot be upgraded to a major version until we drop support for Node 10


### PR DESCRIPTION
Some missing changes from the switch from `main` branch to `master`. This should reinstate our GH actions in the default branch. Also took the chance to replace the `masterIssue` in renovate by the new `dependencyDashboard` option.