### PR TITLE
fix: use shared Prettier configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,32 +1,32 @@
-const { overrides } = require("@netlify/eslint-config-node");
+const { overrides } = require('@netlify/eslint-config-node')
 
 module.exports = {
-  extends: "@netlify/eslint-config-node",
+  extends: '@netlify/eslint-config-node',
   rules: {
     // Those rules from @netlify/eslint-config-node are currently disabled
     // TODO: remove, so those rules are enabled
     complexity: 0,
-    "func-style": 0,
-    "max-lines": 0,
-    "max-params": 0,
-    "max-statements": 0,
-    "no-magic-numbers": 0,
-    "require-await": 0,
-    "fp/no-delete": 0,
-    "fp/no-let": 0,
-    "fp/no-mutating-methods": 0,
-    "fp/no-mutation": 0,
+    'func-style': 0,
+    'max-lines': 0,
+    'max-params': 0,
+    'max-statements': 0,
+    'no-magic-numbers': 0,
+    'require-await': 0,
+    'fp/no-delete': 0,
+    'fp/no-let': 0,
+    'fp/no-mutating-methods': 0,
+    'fp/no-mutation': 0,
   },
   overrides: [
     ...overrides,
     {
-      files: ["src/node-compat/assets/*.js", "test/**/*edge-handlers/*.js"],
+      files: ['src/node-compat/assets/*.js', 'test/**/*edge-handlers/*.js'],
       parserOptions: {
-        sourceType: "module",
+        sourceType: 'module',
       },
       rules: {
-        "node/no-unsupported-features/es-syntax": 0,
+        'node/no-unsupported-features/es-syntax': 0,
       },
     },
   ],
-};
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "Please replace with a clear and descriptive title"
-labels: "type: bug"
-assignees: ""
+title: 'Please replace with a clear and descriptive title'
+labels: 'type: bug'
+assignees: ''
 ---
 
 Thanks for reporting this bug!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "Please replace with a clear and descriptive title"
-labels: "type: feature"
-assignees: ""
+title: 'Please replace with a clear and descriptive title'
+labels: 'type: feature'
+assignees: ''
 ---
 
 <!--

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,16 +11,16 @@ jobs:
       matrix:
         pr:
           [
-            { prefix: "fix", type: "bug" },
-            { prefix: "chore", type: "chore" },
-            { prefix: "test", type: "chore" },
-            { prefix: "ci", type: "chore" },
-            { prefix: "feat", type: "feature" },
-            { prefix: "security", type: "security" },
+            { prefix: 'fix', type: 'bug' },
+            { prefix: 'chore', type: 'chore' },
+            { prefix: 'test', type: 'chore' },
+            { prefix: 'ci', type: 'chore' },
+            { prefix: 'feat', type: 'feature' },
+            { prefix: 'security', type: 'security' },
           ]
     steps:
       - uses: netlify/pr-labeler-action@v1.0.0
         if: startsWith(github.event.pull_request.title, matrix.pr.prefix)
         with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          label: "type: ${{ matrix.pr.type }}"
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          label: 'type: ${{ matrix.pr.type }}'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,14 +17,14 @@ jobs:
         with:
           token: ${{ steps.get-token.outputs.token }}
           release-type: node
-          package-name: "@netlify/plugin-edge-handlers"
+          package-name: '@netlify/plugin-edge-handlers'
       - uses: actions/checkout@v2
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
         with:
-          node-version: "*"
+          node-version: '*'
           check-latest: true
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,7 @@ on:
   # Ensure GitHub actions are not run twice for same commits
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ['*']
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.17.0, "*"]
+        node-version: [10.17.0, '*']
         exclude:
           - os: macOS-latest
             node-version: 10.17.0

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,1 @@
-{
-  "semi": true,
-  "singleQuote": false,
-  "printWidth": 120,
-  "endOfLine": "lf",
-  "proseWrap": "always",
-  "trailingComma": "all"
-}
+"@netlify/eslint-config-node/.prettierrc.json"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = { extends: ["@commitlint/config-conventional"] };
+module.exports = { extends: ['@commitlint/config-conventional'] }

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,1 +1,1 @@
-name: "@netlify/plugin-edge-handlers"
+name: '@netlify/plugin-edge-handlers'

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,85 +1,85 @@
 #!/usr/bin/env node
 
-const path = require("path");
-const process = require("process");
+const path = require('path')
+const process = require('process')
 
-const { isDirectory } = require("path-type");
+const { isDirectory } = require('path-type')
 
-const { assemble, bundleFunctionsForCli } = require("./lib");
+const { assemble, bundleFunctionsForCli } = require('./lib')
 
 const build = async ({ EDGE_HANDLERS_SRC }) => {
-  const srcDir = path.resolve(EDGE_HANDLERS_SRC);
+  const srcDir = path.resolve(EDGE_HANDLERS_SRC)
 
   if (!(await isDirectory(srcDir))) {
     console.log(
       JSON.stringify({
-        code: "directory-not-found",
+        code: 'directory-not-found',
         dir: srcDir,
         success: false,
       }),
-    );
-    return;
+    )
+    return
   }
 
-  let mainFile;
-  let handlers;
+  let mainFile
+  let handlers
   try {
-    const result = await assemble(srcDir);
+    const result = await assemble(srcDir)
     // eslint-disable-next-line prefer-destructuring
-    mainFile = result.mainFile;
+    mainFile = result.mainFile
     // eslint-disable-next-line prefer-destructuring
-    handlers = result.handlers;
+    handlers = result.handlers
   } catch (error) {
     console.log(
       JSON.stringify({
-        code: "unknown",
+        code: 'unknown',
         msg: `Failed discovering Edge Handlers: ${error.message}`,
         success: false,
       }),
-    );
-    return;
+    )
+    return
   }
 
   if (handlers.length === 0) {
-    console.log(JSON.stringify({ bundle: null, bundled: srcDir, handlers: [], success: true }));
-    return;
+    console.log(JSON.stringify({ bundle: null, bundled: srcDir, handlers: [], success: true }))
+    return
   }
 
   try {
-    const bundle = await bundleFunctionsForCli(mainFile);
-    console.log(JSON.stringify({ bundle, bundled: srcDir, handlers, success: true }));
+    const bundle = await bundleFunctionsForCli(mainFile)
+    console.log(JSON.stringify({ bundle, bundled: srcDir, handlers, success: true }))
   } catch (error) {
-    console.log(JSON.stringify(error));
+    console.log(JSON.stringify(error))
   }
-};
+}
 
 const main = async () => {
-  const [, bin, command, EDGE_HANDLERS_SRC] = process.argv;
+  const [, bin, command, EDGE_HANDLERS_SRC] = process.argv
 
-  const USAGE = `Usage: ${bin} build <Edge Handlers directory>`;
+  const USAGE = `Usage: ${bin} build <Edge Handlers directory>`
 
-  if (command !== "build") {
+  if (command !== 'build') {
     console.log(
       JSON.stringify({
-        code: "cli",
+        code: 'cli',
         msg: `'${command}' is not a valid CLI command\n\n${USAGE}`,
         success: false,
       }),
-    );
-    return;
+    )
+    return
   }
   if (!EDGE_HANDLERS_SRC) {
     console.log(
       JSON.stringify({
-        code: "cli",
+        code: 'cli',
         msg: `You must specify the Edge Handlers source directory\n\n${USAGE}`,
         success: false,
       }),
-    );
-    return;
+    )
+    return
   }
 
-  await build({ EDGE_HANDLERS_SRC });
-};
+  await build({ EDGE_HANDLERS_SRC })
+}
 
-main();
+main()

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,7 +1,7 @@
-const path = require("path");
-const process = require("process");
+const path = require('path')
+const process = require('process')
 
-module.exports.LOCAL_OUT_DIR = path.join(process.cwd(), ".netlify", "edge-handlers");
-module.exports.MANIFEST_FILE = "manifest.json";
-module.exports.MAIN_FILE = "__netlifyMain.ts";
-module.exports.CONTENT_TYPE = "application/javascript";
+module.exports.LOCAL_OUT_DIR = path.join(process.cwd(), '.netlify', 'edge-handlers')
+module.exports.MANIFEST_FILE = 'manifest.json'
+module.exports.MAIN_FILE = '__netlifyMain.ts'
+module.exports.CONTENT_TYPE = 'application/javascript'

--- a/src/index.js
+++ b/src/index.js
@@ -1,44 +1,37 @@
-const path = require("path");
-const process = require("process");
+const path = require('path')
+const process = require('process')
 
-const { isDirectory } = require("path-type");
+const { isDirectory } = require('path-type')
 
-const { LOCAL_OUT_DIR } = require("./consts");
-const { assemble, bundleFunctions, logHandlers, publishBundle } = require("./lib");
+const { LOCAL_OUT_DIR } = require('./consts')
+const { assemble, bundleFunctions, logHandlers, publishBundle } = require('./lib')
 
 module.exports = {
   onBuild: async ({ constants: { IS_LOCAL, NETLIFY_API_TOKEN, NETLIFY_API_HOST, EDGE_HANDLERS_SRC }, utils }) => {
     if (!(await isDirectory(EDGE_HANDLERS_SRC))) {
-      return utils.build.failBuild(`Edge Handlers directory does not exist: ${path.resolve(EDGE_HANDLERS_SRC)}`);
+      return utils.build.failBuild(`Edge Handlers directory does not exist: ${path.resolve(EDGE_HANDLERS_SRC)}`)
     }
-    const { mainFile, handlers } = await assemble(EDGE_HANDLERS_SRC);
+    const { mainFile, handlers } = await assemble(EDGE_HANDLERS_SRC)
 
     if (handlers.length === 0) {
-      console.log(`No Edge Handlers were found in ${EDGE_HANDLERS_SRC} directory`);
-      return;
+      console.log(`No Edge Handlers were found in ${EDGE_HANDLERS_SRC} directory`)
+      return
     }
 
-    logHandlers(handlers, EDGE_HANDLERS_SRC);
-    const bundle = await bundleFunctions(mainFile, utils);
-    const uploaded = await publishBundle(
-      bundle,
-      handlers,
-      LOCAL_OUT_DIR,
-      IS_LOCAL,
-      NETLIFY_API_HOST,
-      NETLIFY_API_TOKEN,
-    );
+    logHandlers(handlers, EDGE_HANDLERS_SRC)
+    const bundle = await bundleFunctions(mainFile, utils)
+    const uploaded = await publishBundle(bundle, handlers, LOCAL_OUT_DIR, IS_LOCAL, NETLIFY_API_HOST, NETLIFY_API_TOKEN)
 
     if (!IS_LOCAL) {
       const summaryText = uploaded
         ? `${handlers.length} Edge Handlers deployed.`
-        : `${handlers.length} Edge Handlers did not change.`;
-      const logsLink = `https://app.netlify.com/sites/${process.env.SITE_NAME}/edge-handlers?scope=deployid:${process.env.DEPLOY_ID}`;
+        : `${handlers.length} Edge Handlers did not change.`
+      const logsLink = `https://app.netlify.com/sites/${process.env.SITE_NAME}/edge-handlers?scope=deployid:${process.env.DEPLOY_ID}`
 
       utils.status.show({
-        title: "Edge Handlers",
+        title: 'Edge Handlers',
         summary: `${summaryText} [Watch Logs](${logsLink})`,
-      });
+      })
     }
   },
-};
+}

--- a/src/node-compat/assets/browser.js
+++ b/src/node-compat/assets/browser.js
@@ -1,1 +1,1 @@
-export const browser = true;
+export const browser = true

--- a/src/node-compat/globals.js
+++ b/src/node-compat/globals.js
@@ -1,51 +1,51 @@
-const { randomBytes } = require("crypto");
-const { dirname } = require("path");
+const { randomBytes } = require('crypto')
+const { dirname } = require('path')
 
-const inject = require("@rollup/plugin-inject");
+const inject = require('@rollup/plugin-inject')
 
-const PROCESS_PATH = require.resolve("process-es6");
-const BUFFER_PATH = require.resolve("buffer-es6");
-const BROWSER_PATH = require.resolve("./assets/browser.js");
-const DIRNAME = "\0node-globals:dirname";
-const FILENAME = "\0node-globals:filename";
+const PROCESS_PATH = require.resolve('process-es6')
+const BUFFER_PATH = require.resolve('buffer-es6')
+const BROWSER_PATH = require.resolve('./assets/browser.js')
+const DIRNAME = '\0node-globals:dirname'
+const FILENAME = '\0node-globals:filename'
 
 /** @type {{ [str: string]: string | [string, string] }} */
 const injections = {
-  "process.nextTick": [PROCESS_PATH, "nextTick"],
-  "process.browser": [BROWSER_PATH, "browser"],
-  "Buffer.isBuffer": [BUFFER_PATH, "isBuffer"],
+  'process.nextTick': [PROCESS_PATH, 'nextTick'],
+  'process.browser': [BROWSER_PATH, 'browser'],
+  'Buffer.isBuffer': [BUFFER_PATH, 'isBuffer'],
   process: PROCESS_PATH,
-  Buffer: [BUFFER_PATH, "Buffer"],
+  Buffer: [BUFFER_PATH, 'Buffer'],
   __filename: FILENAME,
   __dirname: DIRNAME,
-};
+}
 
 /** @returns {import("rollup").Plugin} */
 function nodeGlobals() {
-  const dirs = new Map();
+  const dirs = new Map()
   return {
     ...inject({
       modules: injections,
     }),
-    name: "rollup-plugin-node-globals-netlify",
+    name: 'rollup-plugin-node-globals-netlify',
     load(id) {
       if (dirs.has(id)) {
-        return `export default '${dirs.get(id)}'`;
+        return `export default '${dirs.get(id)}'`
       }
     },
     resolveId: (importee, importer) => {
       if (importee === DIRNAME) {
-        const id = randomBytes(15).toString("hex");
-        dirs.set(id, dirname(importer));
-        return id;
+        const id = randomBytes(15).toString('hex')
+        dirs.set(id, dirname(importer))
+        return id
       }
       if (importee === FILENAME) {
-        const id = randomBytes(15).toString("hex");
-        dirs.set(id, importer);
-        return id;
+        const id = randomBytes(15).toString('hex')
+        dirs.set(id, importer)
+        return id
       }
     },
-  };
+  }
 }
 
-module.exports = nodeGlobals;
+module.exports = nodeGlobals

--- a/src/upload.js
+++ b/src/upload.js
@@ -1,6 +1,6 @@
-const fetch = require("node-fetch");
+const fetch = require('node-fetch')
 
-const { CONTENT_TYPE } = require("./consts");
+const { CONTENT_TYPE } = require('./consts')
 
 /**
  * @typedef {{ sha: string, handlers: string[], content_length: number, content_type: string }} BundleInfo
@@ -18,42 +18,42 @@ const { CONTENT_TYPE } = require("./consts");
  */
 async function uploadBundle(buf, info, deployId, apiHost, apiToken) {
   if (!apiToken) {
-    throw new Error("API token is missing");
+    throw new Error('API token is missing')
   }
 
   const resp = await fetch(`https://${apiHost}/api/v1/deploys/${deployId}/edge_handlers`, {
-    method: "POST",
+    method: 'POST',
     body: JSON.stringify(info),
     headers: {
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
       Authorization: `Bearer ${apiToken}`,
     },
-  });
+  })
 
   if (!resp.ok) {
-    throw new Error(`Invalid status: ${resp.status}`);
+    throw new Error(`Invalid status: ${resp.status}`)
   }
 
-  const { error, exists, upload_url: uploadUrl } = await resp.json();
+  const { error, exists, upload_url: uploadUrl } = await resp.json()
   if (error) {
-    throw new Error(`Failed to upload: ${error}`);
+    throw new Error(`Failed to upload: ${error}`)
   }
   if (exists) {
-    return false;
+    return false
   }
   if (!uploadUrl) {
-    throw new Error("Missing upload url");
+    throw new Error('Missing upload url')
   }
 
   await fetch(uploadUrl, {
-    method: "PUT",
+    method: 'PUT',
     body: buf,
     headers: {
-      "Content-Type": CONTENT_TYPE,
+      'Content-Type': CONTENT_TYPE,
     },
-  });
+  })
 
-  return true;
+  return true
 }
 
-module.exports = uploadBundle;
+module.exports = uploadBundle

--- a/test/fixtures/integration-test/edge-handlers/example.js
+++ b/test/fixtures/integration-test/edge-handlers/example.js
@@ -1,6 +1,6 @@
-import { formatDistance, subDays } from "date-fns";
+import { formatDistance, subDays } from 'date-fns'
 
 export async function onRequest() {
-  const timePassed = formatDistance(subDays(new Date(), 3), new Date());
-  console.log(timePassed);
+  const timePassed = formatDistance(subDays(new Date(), 3), new Date())
+  console.log(timePassed)
 }

--- a/test/fixtures/integration-test/edge-handlers/hello_world.js
+++ b/test/fixtures/integration-test/edge-handlers/hello_world.js
@@ -1,13 +1,13 @@
 // eslint-disable-next-line you-dont-need-lodash-underscore/concat
-import { concat } from "lodash";
+import { concat } from 'lodash'
 
-import td from "./data/states.json";
+import td from './data/states.json'
 
 export async function onRequest(ev) {
-  const req = await ev.getRequest();
-  const state = req.headers.get("X-NF-Subdivision-Code");
-  const data = state && td.find((el) => el.state === state);
-  const array = [1];
-  const other = concat(array, 2, [3], [4], data.positive);
-  console.log(other);
+  const req = await ev.getRequest()
+  const state = req.headers.get('X-NF-Subdivision-Code')
+  const data = state && td.find((el) => el.state === state)
+  const array = [1]
+  const other = concat(array, 2, [3], [4], data.positive)
+  console.log(other)
 }

--- a/test/fixtures/missing-modules/edge-handlers/test.js
+++ b/test/fixtures/missing-modules/edge-handlers/test.js
@@ -1,4 +1,4 @@
 // eslint-disable-next-line import/no-unassigned-import, import/no-unresolved, node/no-missing-import
-import "gatsby";
+import 'gatsby'
 
-export const onRequest = () => {};
+export const onRequest = () => {}

--- a/test/fixtures/node-polyfills/edge-handlers/process_version.js
+++ b/test/fixtures/node-polyfills/edge-handlers/process_version.js
@@ -1,5 +1,5 @@
-import process from "process";
+import process from 'process'
 
 export const onRequest = () => {
-  console.log(`Process version is: ${process.version}`);
-};
+  console.log(`Process version is: ${process.version}`)
+}

--- a/test/helpers/bundle.js
+++ b/test/helpers/bundle.js
@@ -1,53 +1,53 @@
-const isPlainObj = require("is-plain-obj");
-const sinon = require("sinon");
+const isPlainObj = require('is-plain-obj')
+const sinon = require('sinon')
 
-const { resolveFixtureName } = require("./fixtures");
-const { normalizeHandler, isValidHandler } = require("./handler");
+const { resolveFixtureName } = require('./fixtures')
+const { normalizeHandler, isValidHandler } = require('./handler')
 
 // Retrieve Edge Handlers bundled handlers
 const loadBundle = function (t, fixtureName) {
-  const { manifest, bundlePath } = loadManifest(t, fixtureName);
-  const handlers = requireBundle(t, bundlePath);
-  return { manifest, handlers };
-};
+  const { manifest, bundlePath } = loadManifest(t, fixtureName)
+  const handlers = requireBundle(t, bundlePath)
+  return { manifest, handlers }
+}
 
 // Load Edge Handlers `manifest.json`
 const loadManifest = function (t, fixtureName) {
-  const fixtureDir = resolveFixtureName(fixtureName);
-  const localOutDir = `${fixtureDir}/.netlify/edge-handlers`;
-  const manifestPath = `${localOutDir}/manifest.json`;
+  const fixtureDir = resolveFixtureName(fixtureName)
+  const localOutDir = `${fixtureDir}/.netlify/edge-handlers`
+  const manifestPath = `${localOutDir}/manifest.json`
   // eslint-disable-next-line import/no-dynamic-require, node/global-require
-  const manifest = require(manifestPath);
+  const manifest = require(manifestPath)
 
-  validateManifest(t, manifest);
+  validateManifest(t, manifest)
 
-  const bundlePath = `${localOutDir}/${manifest.sha}`;
-  return { localOutDir, manifest, bundlePath };
-};
+  const bundlePath = `${localOutDir}/${manifest.sha}`
+  return { localOutDir, manifest, bundlePath }
+}
 
 // Validate that manifest.json has the correct shape
 const validateManifest = function (t, manifest) {
-  t.true(isPlainObj(manifest));
-  t.is(typeof manifest.sha, "string");
-  t.true(Number.isInteger(manifest.content_length));
-  t.true(manifest.content_length > 0);
-  t.is(manifest.content_type, "application/javascript");
-  t.true(Array.isArray(manifest.handlers));
-  t.true(manifest.handlers.every((handler) => typeof handler === "string"));
-};
+  t.true(isPlainObj(manifest))
+  t.is(typeof manifest.sha, 'string')
+  t.true(Number.isInteger(manifest.content_length))
+  t.true(manifest.content_length > 0)
+  t.is(manifest.content_type, 'application/javascript')
+  t.true(Array.isArray(manifest.handlers))
+  t.true(manifest.handlers.every((handler) => typeof handler === 'string'))
+}
 
 // Require the bundle file.
 // Spy on `netlifyRegistry.set()` to retrieve the list of handlers.
 const requireBundle = function (t, bundlePath) {
-  const setRegistry = sinon.spy();
-  global.netlifyRegistry = { set: setRegistry };
+  const setRegistry = sinon.spy()
+  global.netlifyRegistry = { set: setRegistry }
   // eslint-disable-next-line import/no-dynamic-require, node/global-require
-  require(bundlePath);
-  delete global.netlifyRegistry;
+  require(bundlePath)
+  delete global.netlifyRegistry
 
-  const handlers = setRegistry.args.map(normalizeHandler);
-  t.true(handlers.every(isValidHandler));
-  return handlers;
-};
+  const handlers = setRegistry.args.map(normalizeHandler)
+  t.true(handlers.every(isValidHandler))
+  return handlers
+}
 
-module.exports = { loadBundle };
+module.exports = { loadBundle }

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -1,8 +1,8 @@
-const FIXTURES_DIR = `${__dirname}/../fixtures`;
+const FIXTURES_DIR = `${__dirname}/../fixtures`
 
 // Resolve fixture name to an absolute path
 const resolveFixtureName = function (fixtureName) {
-  return `${FIXTURES_DIR}/${fixtureName}`;
-};
+  return `${FIXTURES_DIR}/${fixtureName}`
+}
 
-module.exports = { resolveFixtureName };
+module.exports = { resolveFixtureName }

--- a/test/helpers/handler.js
+++ b/test/helpers/handler.js
@@ -1,37 +1,37 @@
-const sinon = require("sinon");
+const sinon = require('sinon')
 
 // Normalize `netlifyRegistry.set()` spied calls to an object
 const normalizeHandler = function ([name, { onRequest }]) {
-  return { name, onRequest };
-};
+  return { name, onRequest }
+}
 
 // Check whether the handler have the correct shape
 const isValidHandler = function ({ name, onRequest }) {
-  return typeof name === "string" && typeof onRequest === "function";
-};
+  return typeof name === 'string' && typeof onRequest === 'function'
+}
 
 // Call `onRequest(event)` on a specific handler.
 // Retrieve both the handler's return value and logs (`console.log()`)
 const callHandler = async function (t, handlers, name, event) {
-  const exampleHandler = handlers.find((handler) => handler.name === name);
-  t.true(exampleHandler !== undefined);
-  const oldConsoleLog = mockConsoleLog();
-  const returnValue = await exampleHandler.onRequest(event);
-  const logs = unmockConsoleLog(oldConsoleLog);
-  return { returnValue, logs };
-};
+  const exampleHandler = handlers.find((handler) => handler.name === name)
+  t.true(exampleHandler !== undefined)
+  const oldConsoleLog = mockConsoleLog()
+  const returnValue = await exampleHandler.onRequest(event)
+  const logs = unmockConsoleLog(oldConsoleLog)
+  return { returnValue, logs }
+}
 
 // Temporarily mock `console.log()` in order to retrieve the logs
 const mockConsoleLog = function () {
-  const oldConsoleLog = console.log;
-  console.log = sinon.spy();
-  return oldConsoleLog;
-};
+  const oldConsoleLog = console.log
+  console.log = sinon.spy()
+  return oldConsoleLog
+}
 
 const unmockConsoleLog = function (oldConsoleLog) {
-  const logs = console.log.args.flat().join(" ");
-  console.log = oldConsoleLog;
-  return logs;
-};
+  const logs = console.log.args.flat().join(' ')
+  console.log = oldConsoleLog
+  return logs
+}
 
-module.exports = { normalizeHandler, isValidHandler, callHandler };
+module.exports = { normalizeHandler, isValidHandler, callHandler }

--- a/test/helpers/run.js
+++ b/test/helpers/run.js
@@ -1,26 +1,26 @@
-const childProcess = require("child_process");
-const path = require("path");
-const { env } = require("process");
+const childProcess = require('child_process')
+const path = require('path')
+const { env } = require('process')
 
 // Ensure @netlify/build logs have colors. Must be done before requiring it.
-env.FORCE_COLOR = "1";
+env.FORCE_COLOR = '1'
 
-const netlifyBuild = require("@netlify/build");
+const netlifyBuild = require('@netlify/build')
 
-const { resolveFixtureName } = require("./fixtures");
+const { resolveFixtureName } = require('./fixtures')
 
 // Run @netlify/build on a specific fixture directory
 // Retrieve:
 //  - `success` {boolean}: whether build succeeded
 //  - `output` {string}: build logs
 const runNetlifyBuild = async function (t, fixtureName, { expectedSuccess = true } = {}) {
-  const cwd = resolveFixtureName(fixtureName);
-  const { success, logs } = await netlifyBuild({ cwd, buffer: true, telemetry: false });
-  const output = serializeOutput(logs);
-  printOutput({ output, success, expectedSuccess });
-  t.is(success, expectedSuccess);
-  return { output };
-};
+  const cwd = resolveFixtureName(fixtureName)
+  const { success, logs } = await netlifyBuild({ cwd, buffer: true, telemetry: false })
+  const output = serializeOutput(logs)
+  printOutput({ output, success, expectedSuccess })
+  t.is(success, expectedSuccess)
+  return { output }
+}
 
 /**
  * Run a CLI build.
@@ -29,41 +29,41 @@ const runNetlifyBuild = async function (t, fixtureName, { expectedSuccess = true
  * @param {*} fixtureName the fixture to bundle
  */
 const runCliBuild = async (fixtureName, subdir) => {
-  const cliPath = path.join(path.dirname(path.dirname(__dirname)), "src/cli.js");
-  const fixturePath = path.join(path.dirname(__dirname), "fixtures", fixtureName, subdir || "edge-handlers");
+  const cliPath = path.join(path.dirname(path.dirname(__dirname)), 'src/cli.js')
+  const fixturePath = path.join(path.dirname(__dirname), 'fixtures', fixtureName, subdir || 'edge-handlers')
 
-  const options = { maxBuffer: 1024 * 1024 * 32, windowsHide: true };
+  const options = { maxBuffer: 1024 * 1024 * 32, windowsHide: true }
 
   const output = await new Promise((resolve, reject) => {
     childProcess.exec(`node ${cliPath} build ${fixturePath}`, options, (err, stdout) => {
       if (err) {
-        reject(err);
+        reject(err)
       } else {
-        resolve(stdout);
+        resolve(stdout)
       }
-    });
-  });
+    })
+  })
 
-  return JSON.parse(output);
-};
+  return JSON.parse(output)
+}
 
 // @netlify/build stdout/stderr logs are concatenated as an array.
 // This flattens them as a string similar to what would be printed in real logs.
 const serializeOutput = function (logs) {
-  return [logs.stdout.join("\n"), logs.stderr.join("\n")].filter(Boolean).join("\n\n");
-};
+  return [logs.stdout.join('\n'), logs.stderr.join('\n')].filter(Boolean).join('\n\n')
+}
 
 // When the `DEBUG` environment variable is set, print @netlify/build logs
 const printOutput = function ({ output, success, expectedSuccess }) {
   if (!isDebugMode() && success === expectedSuccess) {
-    return;
+    return
   }
 
-  console.log(output);
-};
+  console.log(output)
+}
 
 const isDebugMode = function () {
-  return env.DEBUG === "1";
-};
+  return env.DEBUG === '1'
+}
 
-module.exports = { runCliBuild, runNetlifyBuild };
+module.exports = { runCliBuild, runNetlifyBuild }

--- a/test/main.js
+++ b/test/main.js
@@ -1,71 +1,71 @@
-const test = require("ava");
+const test = require('ava')
 
-const { loadBundle } = require("./helpers/bundle");
-const { callHandler } = require("./helpers/handler");
-const { runCliBuild, runNetlifyBuild } = require("./helpers/run");
+const { loadBundle } = require('./helpers/bundle')
+const { callHandler } = require('./helpers/handler')
+const { runCliBuild, runNetlifyBuild } = require('./helpers/run')
 
-test("Edge Handlers should be bundled", async (t) => {
-  await runNetlifyBuild(t, "integration-test");
+test('Edge Handlers should be bundled', async (t) => {
+  await runNetlifyBuild(t, 'integration-test')
 
-  const { manifest, handlers } = loadBundle(t, "integration-test");
-  t.deepEqual(manifest.handlers.sort(), ["example", "hello_world"]);
+  const { manifest, handlers } = loadBundle(t, 'integration-test')
+  t.deepEqual(manifest.handlers.sort(), ['example', 'hello_world'])
 
-  const example = await callHandler(t, handlers, "example");
-  t.is(example.logs, "3 days");
+  const example = await callHandler(t, handlers, 'example')
+  t.is(example.logs, '3 days')
 
-  const helloWorld = await callHandler(t, handlers, "hello_world", {
-    getRequest: () => ({ headers: { get: () => "AK" } }),
-  });
-  t.is(helloWorld.logs, "1,2,3,4,379");
-});
+  const helloWorld = await callHandler(t, handlers, 'hello_world', {
+    getRequest: () => ({ headers: { get: () => 'AK' } }),
+  })
+  t.is(helloWorld.logs, '1,2,3,4,379')
+})
 
-test("Edge Handlers directory can be configured using build.edge_handlers", async (t) => {
-  await runNetlifyBuild(t, "config-dir");
+test('Edge Handlers directory can be configured using build.edge_handlers', async (t) => {
+  await runNetlifyBuild(t, 'config-dir')
 
-  const { manifest } = loadBundle(t, "config-dir");
-  t.deepEqual(manifest.handlers, ["example"]);
-});
+  const { manifest } = loadBundle(t, 'config-dir')
+  t.deepEqual(manifest.handlers, ['example'])
+})
 
-test("Edge Handlers directory build.edge_handlers misconfiguration is reported", async (t) => {
-  const { output } = await runNetlifyBuild(t, "wrong-config-dir", { expectedSuccess: false });
-  t.true(output.includes("does-not-exist"));
-});
+test('Edge Handlers directory build.edge_handlers misconfiguration is reported', async (t) => {
+  const { output } = await runNetlifyBuild(t, 'wrong-config-dir', { expectedSuccess: false })
+  t.true(output.includes('does-not-exist'))
+})
 
-test("Edge Handlers directory build.edge_handlers syntax error is reported", async (t) => {
-  const { output } = await runNetlifyBuild(t, "syntax-error", { expectedSuccess: false });
-  t.true(output.includes("Error while bundling"));
-});
+test('Edge Handlers directory build.edge_handlers syntax error is reported', async (t) => {
+  const { output } = await runNetlifyBuild(t, 'syntax-error', { expectedSuccess: false })
+  t.true(output.includes('Error while bundling'))
+})
 
-test("Edge Handlers CLI build works", async (t) => {
-  const { code, handlers, msg, success } = await runCliBuild("integration-test");
-  t.true(success, `failed bundling integration test (${code}): ${msg}`);
-  t.true(handlers.length !== 0, "did not include any handlers");
-});
+test('Edge Handlers CLI build works', async (t) => {
+  const { code, handlers, msg, success } = await runCliBuild('integration-test')
+  t.true(success, `failed bundling integration test (${code}): ${msg}`)
+  t.true(handlers.length !== 0, 'did not include any handlers')
+})
 
-test("Edge Handlers CLI build errors on syntax error", async (t) => {
-  const { code, msg, success } = await runCliBuild("syntax-error");
-  t.false(success, `successfully bundled broken test (${code}): ${msg}`);
-});
+test('Edge Handlers CLI build errors on syntax error', async (t) => {
+  const { code, msg, success } = await runCliBuild('syntax-error')
+  t.false(success, `successfully bundled broken test (${code}): ${msg}`)
+})
 
-test("Edge Handlers CLI build bundles custom directories", async (t) => {
-  const { code, handlers, msg, success } = await runCliBuild("config-dir", "custom-edge-handlers");
-  t.true(success, `failed bundling integration test (${code}): ${msg}`);
-  t.true(handlers.length !== 0, "did not include any handlers");
-});
+test('Edge Handlers CLI build bundles custom directories', async (t) => {
+  const { code, handlers, msg, success } = await runCliBuild('config-dir', 'custom-edge-handlers')
+  t.true(success, `failed bundling integration test (${code}): ${msg}`)
+  t.true(handlers.length !== 0, 'did not include any handlers')
+})
 
-test("Edge Handlers CLI outputs missing imports", async (t) => {
-  const { code, importee, importer, msg, success } = await runCliBuild("missing-modules");
-  t.false(success, `failed bundling integration test (${code}): ${msg}`);
-  t.is(importee, "gatsby");
-  t.true(importer.length !== 0);
-  t.true(importer.endsWith(".js"));
-});
+test('Edge Handlers CLI outputs missing imports', async (t) => {
+  const { code, importee, importer, msg, success } = await runCliBuild('missing-modules')
+  t.false(success, `failed bundling integration test (${code}): ${msg}`)
+  t.is(importee, 'gatsby')
+  t.true(importer.length !== 0)
+  t.true(importer.endsWith('.js'))
+})
 
-test("Edge Handlers should polyfill node built in modules", async (t) => {
-  await runNetlifyBuild(t, "node-polyfills");
-  const { manifest, handlers } = loadBundle(t, "node-polyfills");
-  t.deepEqual(manifest.handlers, ["process_version"]);
+test('Edge Handlers should polyfill node built in modules', async (t) => {
+  await runNetlifyBuild(t, 'node-polyfills')
+  const { manifest, handlers } = loadBundle(t, 'node-polyfills')
+  t.deepEqual(manifest.handlers, ['process_version'])
 
-  const processVersion = await callHandler(t, handlers, "process_version");
-  t.is(processVersion.logs, "Process version is: ");
-});
+  const processVersion = await callHandler(t, handlers, 'process_version')
+  t.is(processVersion.logs, 'Process version is: ')
+})


### PR DESCRIPTION
This re-uses the shared Prettier configuration from `@netlify/eslint-config-node`.

This only changes whitespaces, semicolons and quotes.