### PR TITLE
fix: fix automatic `npm publish`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,9 @@ jobs:
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
+      - name: Install dependencies
+        run: npm ci
+        if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         if: ${{ steps.release.outputs.release_created }}
         env:


### PR DESCRIPTION
This fixes the automatic `npm publish`.
`npm ci` must be run first since `npm publish` executes `run-s` which is installed by `@netlify/eslint-config-node`.
See https://github.com/netlify/netlify-plugin-edge-handlers/runs/2622471114?check_suite_focus=true#step:7:11