### PR TITLE
chore: simplify `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,16 +3,5 @@
   ignorePresets: [":prHourlyLimit2"],
   semanticCommits: true,
   dependencyDashboard: true,
-  packageRules: [
-    {
-      // Those cannot be upgraded to a major version until we drop support for Node 10
-      packageNames: [
-        'path-type',
-        'is-plain-obj',
-      ],
-      major: {
-        enabled: false,
-      },
-    },
-  ],
+  packageRules: [],
 }


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/34

This simplifies `renovate.json5` by removing rules already present in our shared configuration.