### PR TITLE
chore!: drop support for Node 10

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.17.0, '*']
+        node-version: [12.20.0, '*']
         exclude:
           - os: macOS-latest
-            node-version: 10.17.0
+            node-version: 12.20.0
           - os: windows-latest
-            node-version: 10.17.0
+            node-version: 12.20.0
       fail-fast: false
     steps:
       - name: Git checkout

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "url": "https://github.com/netlify/netlify-plugin-edge-handlers/issues"
   },
   "engines": {
-    "node": "^10.17.0 || >=11.14.0"
+    "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^15.0.0",


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-plugin-edge-handlers/issues/660

This drops Node 10 support.

This can be reviewed, but can only be released once https://github.com/netlify/build/pull/3873 is released.

I will also fix the branch protection rule right before merging this.