### PR TITLE
chore: remove dead code in `.eslintrc.js`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,10 +19,6 @@ module.exports = {
     'max-statements': 0,
     'no-magic-numbers': 0,
     'require-await': 0,
-    'fp/no-delete': 0,
-    'fp/no-let': 0,
-    'fp/no-mutating-methods': 0,
-    'fp/no-mutation': 0,
   },
   overrides: [...overrides],
 }


### PR DESCRIPTION
This removes some rules not used anymore in `.eslintrc.js`.