### PR TITLE
chore: remove the unused typescript dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,7 @@
         "process-es6": "^0.11.6",
         "rollup": "^2.23.1",
         "rollup-plugin-node-polyfills": "^0.2.1",
-        "rollup-plugin-terser": "^7.0.2",
-        "typescript": "^4.1.5"
+        "rollup-plugin-terser": "^7.0.2"
       },
       "bin": {
         "plugin-build-edge-handlers": "src/cli.js"
@@ -14908,6 +14907,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
       "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26873,7 +26873,8 @@
     "typescript": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "process-es6": "^0.11.6",
     "rollup": "^2.23.1",
     "rollup-plugin-node-polyfills": "^0.2.1",
-    "rollup-plugin-terser": "^7.0.2",
-    "typescript": "^4.1.5"
+    "rollup-plugin-terser": "^7.0.2"
   },
   "devDependencies": {
     "@netlify/build": "^26.1.0",


### PR DESCRIPTION
Noticed this in #829. I don't know if it's really unused, I can only find one `ts` reference in https://github.com/netlify/netlify-plugin-edge-handlers/blob/2c5c9a6837995282c89b78c8bccbff928eb18ca2/src/consts.js#L3

Requires #829.

---

🎉 Thanks for sending this pull request! 🎉

Please make sure the title is clear and descriptive.

If you are fixing a typo or documentation, please skip these instructions.

Otherwise please fill in the sections below.

**Which problem is this pull request solving?**

Example: I'm always frustrated when [...]

**List other issues or pull requests related to this problem**

Example: This fixes #5012

**Describe the solution you've chosen**

Example: I've fixed this by [...]

**Describe alternatives you've considered**

Example: Another solution would be [...]

**Checklist**

Please add a `x` inside each checkbox:

- [x] The status checks are successful (continuous integration). Those can be seen below.
